### PR TITLE
Refactor ft_xpm_to_img function to improve memory management

### DIFF
--- a/incs/img.h
+++ b/incs/img.h
@@ -6,7 +6,7 @@
 /*   By: beroux <beroux@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 22:59:28 by beroux            #+#    #+#             */
-/*   Updated: 2023/08/19 03:12:54 by beroux           ###   ########.fr       */
+/*   Updated: 2023/09/03 04:33:31 by beroux           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -129,7 +129,7 @@ typedef struct s_tileset
 t_uint_img	*init_img(int width, int height);
 
 /** @fn void    clear_img(t_uint_img*img)
- * @brief free all t_uint_imgcontent
+ * @brief free all t_uint_img content
  *
  * @param img the image to clear
  *

--- a/srcs/img/ft_xpm_to_img.c
+++ b/srcs/img/ft_xpm_to_img.c
@@ -6,28 +6,15 @@
 /*   By: beroux <beroux@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/03 04:32:14 by beroux            #+#    #+#             */
-/*   Updated: 2023/09/03 04:39:40 by beroux           ###   ########.fr       */
-/*                                                                            */
-/* ************************************************************************** */
-
-/* ************************************************************************** */
-/*                                                                            */
-/*                                                        :::      ::::::::   */
-/*   ft_xpm_to_img.c                                    :+:      :+:    :+:   */
-/*                                                    +:+ +:+         +:+     */
-/*   By: beroux <beroux@student.42lyon.fr>          +#+  +:+       +#+        */
-/*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/01/23 22:08:37 by beroux            #+#    #+#             */
-/*   Updated: 2023/05/24 12:48:22 by beroux           ###   ########lyon.fr   */
+/*   Updated: 2023/09/05 16:47:54 by beroux           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub.h"
 
-t_uint_img	ft_xpm_to_img(void *mlx_ptr, char *path)
+t_uint_img	*ft_xpm_to_img(void *mlx_ptr, char *path)
 {
 	t_uint_img	*img;
-	t_uint_img	res;
 	t_mlx_img	*mlx_img;
 	int			*width_p;
 	int			*height_p;
@@ -35,16 +22,14 @@ t_uint_img	ft_xpm_to_img(void *mlx_ptr, char *path)
 	mlx_img = ft_calloc(1, sizeof(t_mlx_img));
 	img = NULL;
 	if (!mlx_img)
-		return ((t_uint_img) {NULL, 0, 0});
+		return (NULL);
 	width_p = &(mlx_img->width);
 	height_p = &(mlx_img->height);
 	mlx_img->content = mlx_xpm_file_to_image(mlx_ptr, path, width_p, height_p);
 	if (!mlx_img->content)
-		return (free(mlx_img), (t_uint_img) {NULL, 0, 0});
+		return (free(mlx_img), NULL);
 	mlx_img_to_img(&img, mlx_img);
 	mlx_destroy_image(mlx_ptr, mlx_img->content);
 	free(mlx_img);
-	res = *img;
-	free(img);
-	return (res);
+	return (img);
 }


### PR DESCRIPTION
The most significant change in this commit was to the `ft_xpm_to_img` function and its return type. Instead of returning a value, it now returns a pointer, which simplifies the memory management by allowing direct usage of the created image object instead of copying it. This also removed the necessity to free the original object, preventing memory leaks. Additionally, unnecessary comments and a redundant assignment were removed for neatness and clarity. In the img.h file, a space was added in the comment for correct spelling.