### PR TITLE
check unexpected char

### DIFF
--- a/incs/parsing.h
+++ b/incs/parsing.h
@@ -6,7 +6,7 @@
 /*   By: gd-harco <gd-harco@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 10:52:54 by gd-harco          #+#    #+#             */
-/*   Updated: 2023/09/14 16:06:35 by beroux           ###   ########.fr       */
+/*   Updated: 2023/09/14 17:56:01 by gd-harco         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ void	free_textures_line(char *textures_line[4]);
 void	get_line_no_whitespace(char *buff, char **line, int *data_got);
 void	get_textures_line(char *buff, char *line_array[4], int *data_got);
 
-int	get_color(char *buff, uint32_t color[2], int *data_got);
+int		get_color(char *buff, uint32_t color[2], int *data_got);
 
 int		get_map(int fd, t_data *data);
 
@@ -56,18 +56,21 @@ of info in provided file\033[0m\n"
 # define ERM_ARRAY_BIGGER "\033[1;31mcub3D: Error: \
 to many info on line %c\033[0m\n"
 # define ERC_ARRAY_BIGGER 106
-# define ERM_OOR_VALUE "\033[1;31mcub3D: Error: color value out of range\033[0m\n"
+# define ERM_OOR_VALUE "\033[1;31mcub3D: Error: \
+color value out of range\033[0m\n"
 # define ERC_OOR_VALUE 107
 # define ERM_NO_MAP  "\033[1;31mcub3D: Error: No map found \
 in provided file\033[0m\n"
 # define ERC_NO_MAP 108
 # define ERM_UNCLOSED "\033[1;31mcub3D: Error: Unclosed map\033[0m\n"
 # define ERC_UNCLOSED 109
-# define ERM_UNEXPECTED "\033[1;31mcub3D: Error: Unexpected character at "
+# define ERM_UNEXPECTED "\033[1;31mcub3D: \
+Error: Unexpected character \"%c\" at [%d][%d]\033[0m\n"
 # define ERC_UNEXPECTED 110
 # define ERM_PLAYER "\033[1;31mcub3D: Error: Multiple player \
 in provided file\033[0m\n"
 # define ERC_PLAYER 111
-# define ERM_NO_PLAYER "\033[1;31mcub3D: Error: Player position not found\033[0m"
+# define ERM_NO_PLAYER "\033[1;31mcub3D: \
+Error: Player position not found\033[0m"
 # define ERC_NO_PLAYER 112
 #endif

--- a/srcs/parsing/check_map.c
+++ b/srcs/parsing/check_map.c
@@ -6,14 +6,14 @@
 /*   By: gd-harco <gd-harco@student.42lyon.fr>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/09 18:23:42 by gd-harco          #+#    #+#             */
-/*   Updated: 2023/09/13 12:58:49 by gd-harco         ###   ########.fr       */
+/*   Updated: 2023/09/14 17:55:36 by gd-harco         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub.h"
 
 int	check_enclosed_map(t_map *map, t_player player);
-int	flood_algo(char **map, t_vec_2i pos, t_vec_2i size);
+int	flood_algo(char **map, t_vec_2i pos, t_vec_2i size, int *ret);
 
 int	check_map_and_player(t_data *data)
 {
@@ -32,32 +32,38 @@ int	check_enclosed_map(t_map *map, t_player player)
 {
 	t_vec_2i	pos;
 	char		**map_copy;
+	int			ret;
 
+	ret = 0;
 	pos.x = (int)player.pos[0] / CELL_SIZE;
 	pos.y = (int)player.pos[1] / CELL_SIZE;
 	map_copy = (char **)ft_array_dup((void **)map->content, false, true);
-	if (flood_algo(map_copy, pos, map->size))
-		return (ft_free_array((void **)map_copy),
-			ft_dprintf(2, ERM_UNCLOSED), ERC_UNCLOSED);
+	map_copy[pos.y][pos.x] = '0';
+	flood_algo(map_copy, pos, map->size, &ret);
+	if (ret)
+		return (ft_free_array((void **)map_copy), ret);
 	return (ft_free_array((void **)map_copy), EXIT_SUCCESS);
 }
 
-int	flood_algo(char **map, t_vec_2i pos, t_vec_2i size)
+int	flood_algo(char **map, t_vec_2i pos, t_vec_2i size, int *ret)
 {
+	if (*ret)
+		return (*ret);
 	if (pos.x < 0 || pos.x >= size.x || pos.y < 0 || pos.y >= size.y)
-		return (ERC_UNCLOSED);
+		return (ft_dprintf(2, ERM_UNCLOSED), ERC_UNCLOSED);
+	if (map[pos.y][pos.x] != '0' && map[pos.y][pos.x]
+		!= '1' && map[pos.y][pos.x] != ' ')
+		return (ft_dprintf(2, ERM_UNEXPECTED, map[pos.y][pos.x],
+			pos.x, pos.y), ERC_UNEXPECTED);
 	if (map[pos.y][pos.x] == '1')
 		return (EXIT_SUCCESS);
-	if (map[pos.y][pos.x] == ' ')
-		return (ERC_UNCLOSED);
+	if (map[pos.y][pos.x] == ' ' && (pos.x == 0 || pos.x == size.x - 1
+			|| pos.y == 0 || pos.y == size.y - 1))
+		return (ft_dprintf(2, ERM_UNCLOSED), ERC_UNCLOSED);
 	map[pos.y][pos.x] = '1';
-	if (flood_algo(map, (t_vec_2i){pos.x + 1, pos.y}, size))
-		return (ERC_UNCLOSED);
-	if (flood_algo(map, (t_vec_2i){pos.x - 1, pos.y}, size))
-		return (ERC_UNCLOSED);
-	if (flood_algo(map, (t_vec_2i){pos.x, pos.y + 1}, size))
-		return (ERC_UNCLOSED);
-	if (flood_algo(map, (t_vec_2i){pos.x, pos.y - 1}, size))
-		return (ERC_UNCLOSED);
-	return (EXIT_SUCCESS);
+	*ret = flood_algo(map, (t_vec_2i){pos.x + 1, pos.y}, size, ret);
+	*ret = flood_algo(map, (t_vec_2i){pos.x - 1, pos.y}, size, ret);
+	*ret = flood_algo(map, (t_vec_2i){pos.x, pos.y + 1}, size, ret);
+	*ret = flood_algo(map, (t_vec_2i){pos.x, pos.y - 1}, size, ret);
+	return (*ret);
 }


### PR DESCRIPTION
Now check for unautorized charactere inside map.
The choice has been made to ignore unautorized charactere that are outside the map boundary
- Improve error messages consistency and clarity
- Refine map checking algorithm and exception handling
