### PR TITLE
Remove minimap toggle from key release, add minimap.c to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: beroux <beroux@student.42lyon.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/08/15 03:36:50 by beroux            #+#    #+#              #
-#    Updated: 2023/09/13 18:00:16 by beroux           ###   ########.fr        #
+#    Updated: 2023/09/19 16:12:23 by beroux           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -16,7 +16,7 @@ IS_BONUS =	0
 
 ifeq ($(IS_BONUS), 1)
 	NAME 		=	cub3D_bonus
-	SRCS 		=	main_bonus.c hooks_bonus.c mouse_hooks_bonus.c
+	SRCS 		=	main_bonus.c hooks_bonus.c mouse_hooks_bonus.c minimap.c
 	INCS_DIR	=	$(BASE_INCLUDED) bonus/incs
 	INCS_FLAGS	=	$(addprefix -I, $(INCS_DIR))
 	INCS 		=	bonus/incs/cub_bonus.h

--- a/bonus/srcs/hooks_bonus.c
+++ b/bonus/srcs/hooks_bonus.c
@@ -45,15 +45,11 @@ int	on_key_press(int keycode, t_data *data)
 int	on_key_released(int keycode, t_data *data)
 {
 	key_released_player(keycode, data);
-	if (keycode == XK_Tab)
-		data->show_minimap = !data->show_minimap;
 	return (0);
 }
 
 int	on_loop(t_data *data)
 {
-	t_uint_img	*minimap;
-
 	if (data->player.mov[0] == 0 && data->player.mov[1] == 0 && \
 		data->player.angle_mov == 0)
 		return (0);


### PR DESCRIPTION
The minimap toggling feature was removed from the 'on_key_released' function due to conflicts with other key commands. The minimap has been separated into its own file, 'minimap.c', which has been added to the 'SRCS' variable in the Makefile. This separation will isolate and centralize minimap-related functions, increasing maintainability.