### PR TITLE
Updated minimap toggle to re-render window immediately

### DIFF
--- a/bonus/srcs/hooks_bonus.c
+++ b/bonus/srcs/hooks_bonus.c
@@ -6,7 +6,7 @@
 /*   By: beroux <beroux@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 08:20:53 by beroux            #+#    #+#             */
-/*   Updated: 2023/09/19 17:01:46 by gd-harco         ###   ########.fr       */
+/*   Updated: 2023/09/19 17:11:25 by gd-harco         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,10 @@ int	on_destroy(t_data *data)
 int	on_key_press(int keycode, t_data *data)
 {
 	if (keycode == XK_Tab)
+	{
 		data->show_minimap = !data->show_minimap;
+		render_to_window(data);
+	}
 	if (keycode == XK_Escape)
 		on_destroy(data);
 	key_press_player(keycode, data);


### PR DESCRIPTION
Previously, when the minimap toggle key was hit, the map was not immediately rendered on the screen until the next frame update. The code refactor now calls 'render_to_window' function immediately after toggling the minimap, ensuring that the map is displayed in sync with the action.
