### PR TITLE
fix conditional jump in cos call

### DIFF
--- a/bonus/srcs/render/raycast_bonus.c
+++ b/bonus/srcs/render/raycast_bonus.c
@@ -6,7 +6,7 @@
 /*   By: beroux <beroux@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/15 14:28:49 by beroux            #+#    #+#             */
-/*   Updated: 2023/10/08 16:07:32 by beroux           ###   ########.fr       */
+/*   Updated: 2023/10/08 18:09:17 by beroux           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,8 +42,8 @@ static void	cast_ray(t_data *data, int i, t_angle_data *current_angle)
 	cast_vert(data, data->player.pos, current_angle, &ray_vert, data->map);
 	cast_horiz(data, data->player.pos, current_angle, &ray_horiz, data->map);
 	data->buffers[i].ray = select_ray(ray_horiz, ray_vert);
-	data->buffers[i].ray.dist *= \
-		cos((data->player.angle.deg - (*current_angle).deg) * M_PI_4 / 45);
+	data->buffers[i].ray.angle_diff = data->player.angle.deg - \
+										current_angle->deg;
 	(*current_angle).deg += data->player.fov / WIN_WIDTH;
 	(*current_angle).deg = fmod((fmod((*current_angle).deg, 360) + 360), 360);
 	(*current_angle).rad += data->offset_raycast.rad;


### PR DESCRIPTION
Refactored how the fisheye effect is corrected in ray_cast function in 'raycast_bonus.c'. Previously, the error was directly corrected by modifying the ray distance which was causing distortion. Now, the angular difference is calculated and stored separately for more accurate image rendering. This adjustment brings us one step closer to achieving a more realistic 3D effect.