### PR TITLE
Normed gamepad related function (change update_gamepads return type from int to void)

### DIFF
--- a/bonus/incs/gamepad_bonus.h
+++ b/bonus/incs/gamepad_bonus.h
@@ -94,7 +94,7 @@ typedef struct s_gamepad
 
 t_gamepad	*init_gamepads(int nb_gamepads);
 void		clear_gamepads(t_gamepad **gamepads);
-int			update_gamepads(t_gamepad *gamepads);
+void		update_gamepads(t_gamepad *gamepads);
 void		*input_loop(t_gamepad *gamepad);
 int			update_inputs(t_gamepad *gamepad);
 

--- a/bonus/srcs/gamepad/clear_gamepads_bonus.c
+++ b/bonus/srcs/gamepad/clear_gamepads_bonus.c
@@ -42,7 +42,7 @@ void	clear_gamepads(t_gamepad **list)
 
 static void	clear_mutexes(t_gamepad *gamepad)
 {
-	int i;
+	int	i;
 
 	i = 0;
 	pthread_mutex_destroy(gamepad->mutex);

--- a/bonus/srcs/gamepad/init_gamepads_bonus.c
+++ b/bonus/srcs/gamepad/init_gamepads_bonus.c
@@ -61,7 +61,7 @@ static int	add_gamepad(t_gamepad **list)
 
 static int	init_mutexes(t_gamepad *gamepad)
 {
-	int i;
+	int	i;
 
 	i = 0;
 	gamepad->mutex = malloc(sizeof (pthread_mutex_t));

--- a/bonus/srcs/gamepad/update_gamepads_bonus.c
+++ b/bonus/srcs/gamepad/update_gamepads_bonus.c
@@ -17,7 +17,7 @@ static struct dirent	*get_next_controller(char *dir_path, DIR *dir);
 static int				check_node(char *dir_path, struct dirent *node);
 static bool				is_in_gamepads(ino_t inode, t_gamepad *gamepads);
 
-int	update_gamepads(t_gamepad *gamepads)
+void	update_gamepads(t_gamepad *gamepads)
 {
 	struct dirent	*next;
 	t_gamepad		*tmp;
@@ -27,7 +27,7 @@ int	update_gamepads(t_gamepad *gamepads)
 	check_disconnections(gamepads);
 	events_dir = opendir("/dev/input/");
 	if (!events_dir)
-		return (0);
+		return ;
 	next = get_next_controller("/dev/input/", events_dir);
 	while (tmp && tmp->connected)
 		tmp = tmp->next;
@@ -44,7 +44,6 @@ int	update_gamepads(t_gamepad *gamepads)
 			tmp = tmp->next;
 	}
 	closedir(events_dir);
-	return (0);
 }
 
 static void	check_disconnections(t_gamepad *gamepads)

--- a/bonus/srcs/gamepad/update_inputs_bonus.c
+++ b/bonus/srcs/gamepad/update_inputs_bonus.c
@@ -34,7 +34,7 @@ int	update_inputs(t_gamepad *gamepad)
 
 static void	register_input(t_gamepad *gamepad, struct js_event event)
 {
-	int i;
+	int	i;
 
 	i = 0;
 	pthread_mutex_lock(gamepad->states[i].mutex);


### PR DESCRIPTION
Adjusted the return type of update_gamepads function from int to void in the gamepad_bonus files since the return value wasn't being used elsewhere. This alows the function to be less than 25 line. Fixed the format of variable 'i' in multiple files to stay consistent and improve readability. Added or maintained newlines at end of files to comply with POSIX standards.
